### PR TITLE
Adding docs and git section

### DIFF
--- a/Docs/Contributing.md
+++ b/Docs/Contributing.md
@@ -92,4 +92,17 @@ It is helpful to create a local branch or tag to denote which commit relates
 to which internal version. 
 
 
+## Adding a new page
 
+1. Create the new `.md` file under `/_styleguide`.
+2. Add the title for the md file at the top with the following syntax. This will set the page title, and what is shown on the collections page.
+
+    ```
+    ---
+    title: "Title here"  
+    ---
+    ```
+
+3. Add the link on the home page (`index.md`)
+4. Add the link to the side bar nav (`_data/navigation.yml`)
+5. Add the content.

--- a/Docs/Contributing.md
+++ b/Docs/Contributing.md
@@ -1,0 +1,95 @@
+## General repository overview
+The site is made up of a number of markdown files, mostly in 
+`/_styleguide/`, which are rendered into HTML using Jekyll. 
+
+The theme is 
+[Minimal Mistakes](https://mmistakes.github.io/minimal-mistakes/)
+as this provides good flexibility in the design, and has a good depth and range 
+of documentation.
+
+Pages in `/_styledguide/` form a 'collection', and are automatically grouped
+[(see here)](https://accis.github.io/StyleGuide/styleguide/) and assigned 
+the same style according to the settings in `_config.yml` under `defaults`.
+The page which shows the whole collection is provided by `/_pages/styleguide.md`
+
+Navigation in the sidebar is provided by `/_data/navigation.yml`
+
+
+## Set up and run a local version
+
+Install prerequisites from [Jekyll](https://jekyllrb.com/docs/) 
+(Ruby, RubyGems, GCC, and Make)
+
+Install Jekyll and bundler 
+
+    gem install jekyll bundler
+
+Navigate to the directory containing the Gemfile, i.e. the root directory 
+of this repo
+
+    cd path/to/source/Gemfile
+
+Install the required Gems
+
+    bundle install
+
+Now we're ready to launch the local host
+
+    bundle exec jekyll serve
+
+Which can then be viewed at 
+
+    http://localhost:4000/StyleGuide/
+
+
+## Creating a PDF document
+To be able to archive this guide following the UTC conventions, a PDF needs 
+generating. 
+This is achieved using [Pandoc](https://pandoc.org/index.html) and Python 3.x. 
+
+Installation of Pandoc is very simple, on Windows at least, as it is all taken
+care of using the [installer](https://pandoc.org/installing.html). 
+
+Once installed, the PDF can be generated using the python script by:
+
+    python Scripts/create_pdf.py
+
+Only core Python libraries are needed, so there is no need to configure any 
+virtual environments. 
+
+
+The markdown files are appended into a single file according to `file_order` in
+`/Scripts/create_pdf.py` and then passed through to pandoc using `subprocess`.
+Accordingly, the structure of the PDF can be easily modified and extended. 
+The [documentation](https://pandoc.org/MANUAL.html) for Pandoc is rather extensive, and provides a number of 
+ways that the style of the generated PDF can be modified, though these have not
+been investigated thoroughly.
+
+## Deploying a new version
+New development should take place on (or branched from, and PRd back) the Main 
+branch. 
+Once ready to update the [website](https://accis.github.io/StyleGuide/), the 
+`gh-pages` branch will need updating to point to the tip of the Main branch. 
+This is achieved by:
+
+    git checkout gh-pages
+    git rebase main
+    git push
+
+When deploying a new version, a PDF must be generated with the internal version
+number adorned on the first page.
+
+The following text should be added as the first content after the YAML header:
+
+    Internal version number: <version reference>
+
+To get the version number, please talk to
+Matt Edwards ([m.edwards@bristol.ac.uk](mailto:m.edwards@bristol.ac.uk))
+or
+Stephen Hallett ([Stephen.Hallett@bristol.ac.uk](mailto:Stephen.Hallett@bristol.ac.uk))
+
+It is helpful to create a local branch or tag to denote which commit relates 
+to which internal version. 
+
+
+

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,3 +16,5 @@ docs:
         url: /styleguide/version_control/
       - title: "Language Specifics"
         url: /styleguide/languages/
+      - title: "Getting Started with Git"
+        url: /styleguide/getting_started_with_git/

--- a/_styleguide/IDEs_and_tools.md
+++ b/_styleguide/IDEs_and_tools.md
@@ -158,6 +158,7 @@ options menu.
 {: .notice--info}
 
 Here are a few useful shortcuts, in VS Code, for writing software:
+
 * Jump to function definition (`F12`)
 * Move to start/end of line (`home/end`)
 * Move cursor to next word (`ctrl + left/right`)

--- a/_styleguide/getting_started_with_git.md
+++ b/_styleguide/getting_started_with_git.md
@@ -1,0 +1,79 @@
+---
+title: "Getting started with Git"
+---
+
+# Getting started
+If you're relatively new to Git, have never heard of Git, or just want a 
+refresher on the basics, then the first thing to do is to follow the 
+[Bristol RSE](https://www.bristol.ac.uk/acrc/research-software-engineering/)
+workshop on 
+[Introducing Git](https://chryswoods.com/introducing_git/).
+
+This course assumes you have no prior knowledge of Git and starts right from 
+installing and configuring Git. It is designed to be covered at a reasonably 
+quick pace in a 3 hour workshop, however, this is certainly not enough time to 
+properly explore and experiment with Git to build familiarity. Therefore, it is 
+likely to take about a day to get through at your own pace. While the basic 
+commands can be learned in a day, it will likely take several days/weeks of 
+regular usage to become confident.
+
+While Git can take a fair bit of practice to feel fully comfortable with, 
+the day-to-day tasks are fairly simple; there are really only ~6-7 commands 
+that will be used on a regular basis. 
+
+If you have any questions, no matter how trivial it may seem, please contact 
+Matt Edwards ([m.edwards@bristol.ac.uk](mailto:m.edwards@bristol.ac.uk))
+or the 
+Ask-RSE mailbox ([ask-rse@bristol.ac.uk](mailto:ask-rse@bristol.ac.uk)).
+
+## Optional Pre-requisite
+Note that Git is commonly used as a command line tool, and so it helps (though is
+not necessary) to have a basic understanding of the Command Line Interface (CLI).
+The Bristol RSE team also provide a workshop introducing the CLI for unix (i.e
+linux and mac) machines 
+[here](https://altanner.github.io/intro_to_CLI/). 
+
+For Windows users: It is worth noting that 'Git Bash', which is what you will 
+likely start off using if you download from the git website (links in the 
+Introducing Git course), is a unix-like terminal and so the previous workshop
+will likely still be helpful. 
+
+Although commonly used in the CLI, Git definitely benefits from the use of a 
+Graphical User Interface, for which 
+[there are many](https://git-scm.com/downloads/guis). 
+Choice of GUI is a personal preference; find which works for you. If you are
+completely new to Git then 
+[GitHub Desktop](https://desktop.github.com/)
+is a safe option.
+
+
+# Next Steps
+Once you are more comfortable using Git for the day-to-day tasks of tracking 
+changes through commits, it is helpful to learn how to use Git in a 
+collaborative manner, using services such as GitHub and GitLab. 
+
+This is covered in the Bristol RSE workshop 
+[Git for Collaboration](https://chryswoods.com/git_collaboration/)
+which assumes that you have completed the Introducing Git workshop from above.
+The course focusses on branching, pulling, cloning, and all the skills necessary
+to work with someone else on code.
+
+This workshop is also designed to be taught at a reasonably quick pace in a 
+3 hour workshop. Note that the pace is fast so as to cover as much ground as 
+possible, but it will definitely take longer to go through at your own pace.
+
+
+# Support
+The Bristol RSE group provide _free_ training to UoB Staff and Postgrads on Git
+roughly once per term. Please visit the 
+[training schedule](https://www.bristol.ac.uk/acrc/acrc-training/)
+to find out when the next course is and sign up.
+
+If you have other questions in the meantime, no matter how trivial it may seem,
+please contact 
+Matt Edwards ([m.edwards@bristol.ac.uk](mailto:m.edwards@bristol.ac.uk))
+or the 
+Ask-RSE mailbox ([ask-rse@bristol.ac.uk](mailto:ask-rse@bristol.ac.uk)).
+
+Finally, the best way to learn Git is to experiment for yourself. 
+Go and have a try. 

--- a/_styleguide/languages.md
+++ b/_styleguide/languages.md
@@ -25,12 +25,14 @@ It should be noted that this document is from 1996, and so some aspects may
 no longer be considered best practice. 
 
 Some other useful documents:
+
 * [Fortran90.org best practices](https://www.fortran90.org/src/best-practices.html)
     * Community driven
 * [Fortran FOSS best practices](https://github.com/Fortran-FOSS-Programmers/Best_Practices#explicit)
     * Also community driven, fairly concise and with good examples.
 * [Compact F95 Language Summary](https://www.csee.umbc.edu/~squire/fortranclass/summary.shtml)
     * Very good as a quick reference
+    
 ## C++
 
 A widely regarded, including by RR, style guide to follow is the 

--- a/_styleguide/version_control.md
+++ b/_styleguide/version_control.md
@@ -166,6 +166,7 @@ sharing and distributing our code significantly easier, such as
 Although Git may seem complex and daunting at first, once you have learnt the
 basics you will realise that 95\% of using git relies on just a handful of 
 commands, which essentially boil down to
+
 * Select which modifications you would like to save
 * Describe the modifications
 * Commit (save) the changes

--- a/index.md
+++ b/index.md
@@ -24,4 +24,4 @@ sidebar:
 
 * [Language Specifics](/StyleGuide/styleguide/languages/)
 
-
+* [Getting started with Git](/StyleGuide/styleguide/getting_started_with_git)


### PR DESCRIPTION
Adds a brief 'contributing' guide to help remember how to contribute/develop/add pages etc. 

Adds a 'getting started with git' section, which signposts the introducing git and git for collaboration course. This will be a helpful place to signpost new users to rather than having to explain the steps each time. 